### PR TITLE
[cairo] fontconfig should not be requiered if x11 is not enabled

### DIFF
--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -18,7 +18,9 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/sr
 
 if("freetype" IN_LIST FEATURES)
     set(CAIRO_HAS_FT_FONT TRUE)
-    set(CAIRO_HAS_FC_FONT TRUE)
+    if ("x11" IN_LIST FEATURES)
+        set(CAIRO_HAS_FC_FONT TRUE)
+    endif()
 endif()
 configure_file("${CMAKE_CURRENT_LIST_DIR}/cairo-features.h.in" "${SOURCE_PATH}/src/cairo-features.h")
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
